### PR TITLE
NEW autogenerate project reference in API

### DIFF
--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -284,6 +284,8 @@ class Projects extends DolibarrApi
 	 */
 	public function post($request_data = null)
 	{
+		global $conf;
+		
 		if (!DolibarrApiAccess::$user->hasRight('projet', 'creer')) {
 			throw new RestException(403, "Insuffisant rights");
 		}
@@ -306,6 +308,41 @@ class Projects extends DolibarrApi
 		  }
 		  $this->project->lines = $lines;
 		}*/
+
+		// Auto-generate the "ref" field if it is set to "auto"
+		 if ($this->project->ref == -1 || $this->project->ref === 'auto') {
+			$defaultref = '';
+			$modele = !getDolGlobalString('PROJECT_ADDON') ? 'mod_project_simple' : $conf->global->PROJECT_ADDON;	
+			$file = '';
+			$classname = '';
+			$filefound = 0;
+			$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+			foreach ($dirmodels as $reldir) {
+				$file = dol_buildpath($reldir."core/modules/project/".$modele.'.php', 0);
+				if (file_exists($file)) {
+					$filefound = 1;
+					$classname = $modele;
+					break;
+				}
+			}
+	
+			if ($filefound) {
+				$result = dol_include_once($reldir."core/modules/project/".$modele.'.php');
+				$modProject = new $classname();
+				$defaultref = $modProject->getNextValue(null, $this->project);
+			}
+	
+			if (is_numeric($defaultref) && $defaultref <= 0) {
+				$defaultref = '';
+			}
+	
+			if (empty($defaultref)) {
+				$defaultref = 'PJ'.dol_print_date(dol_now(), 'dayrfc');
+			}
+	
+			$this->project->ref = $defaultref;
+		}
+		
 		if ($this->project->create(DolibarrApiAccess::$user) < 0) {
 			throw new RestException(500, "Error creating project", array_merge(array($this->project->error), $this->project->errors));
 		}


### PR DESCRIPTION


# NEW[*autogenerate project reference in API*]
[*When posting to projects via the API it was not possible to auto-assign a reference like for third parties. 

This commit uses the assigned numbering module like in /public/project/new.php and assigns it when ref = "auto" like in the third parties API class.*]

